### PR TITLE
Add circleci linting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+dependencies:
+  post:
+    - pip install git+https://github.com/DataDog/workbench-tooling.git
+
+test:
+  override:
+    - mkdir -p ~/.local/share/DataDog
+    - ln -s ~/workbench-recipes ~/.local/share/DataDog/
+    - workbench lint


### PR DESCRIPTION
Using `workbench lint`, lint recipes files before merging. The `lint` command needs to improve, but using it will avoid setting a test framework for this repo. It should validate:
  - manifest.yaml files, checking for required fields
  - auto_conf templates, ditto
  - docker-compose.yaml and *.compose files with `docker-compose config`

For now, we are using `workbench-tooling:master`, but we'll move to a tag when code is a bit more stable.