### PR TITLE
add new template_in_labels jmx variant

### DIFF
--- a/jmx/manifest.yaml
+++ b/jmx/manifest.yaml
@@ -3,3 +3,6 @@ flavors:
   helloworld:
     description: Simple "hello world" java app with JMX enabled
     compose_file: helloworld.compose
+  template_in_labels:
+    description: JMX app with autoconf template in the container labels (5.17+ only)
+    compose_file: template_in_labels.compose

--- a/jmx/template_in_labels.compose
+++ b/jmx/template_in_labels.compose
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  jmx-template_in_labels:
+    build: .
+    labels:
+      service-discovery.datadoghq.com/check_names: '["jmx"]'
+      service-discovery.datadoghq.com/init_configs: '[{}]'
+      service-discovery.datadoghq.com/instances: '[{"host": "%%host%%", "port": "%%port%%"}]'
+networks:
+  default:
+    external:
+      name: workbench


### PR DESCRIPTION
add new jmx variant to test the 5.17 feature of giving an AD template in container labels