### PR TITLE
Add php-fpm recipe

### DIFF
--- a/php-fpm/README.md
+++ b/php-fpm/README.md
@@ -1,0 +1,8 @@
+# php-fpm
+This workbench creates a php-fpm service behind a nginx server.
+
+## Running
+* Launching php-fpm with nginx
+```bash
+COMPOSE_FILE=fpm-nginx.compose version=7.0-fpm docker-compose up
+```

--- a/php-fpm/auto_conf/php_fpm.yaml
+++ b/php-fpm/auto_conf/php_fpm.yaml
@@ -1,0 +1,42 @@
+docker_images:
+  - php_fpm
+
+init_config:
+
+instances:
+  - # Get metrics from your FPM pool with this URL
+    status_url: "http://%%host%%/status"
+    # Get a reliable service check of your FPM pool with that one
+    ping_url: "http://%%host%%/ping"
+    # Set the expected reply to the ping.
+    ping_reply: pong
+    # These 2 URLs should follow the options from your FPM pool
+    # See http://php.net/manual/en/install.fpm.configuration.php
+    #   * pm.status_path
+    #   * ping.path
+    # You should configure your fastcgi passthru (nginx/apache) to
+    # catch these URLs and redirect them through the FPM pool target
+    # you want to monitor (FPM `listen` directive in the config, usually
+    # a UNIX socket or TCP socket.
+    #
+    # Use this if you have basic authentication on these pages
+    # user: bits
+    # password: D4T4D0G
+    #
+    # If your FPM pool is only accessible via a specific HTTP vhost, you can
+    # pass in a custom Host header like so
+    # http_host: such.production.host
+    #
+    # If you need to specify a custom timeout in seconds (default is 20):
+    # timeout: 20
+    #
+    # The (optional) disable_ssl_validation will instruct the check
+    # to skip the validation of the SSL certificate of the URL being tested.
+    # Defaults to false, set to true if you want to disable SSL certificate validation.
+    #
+    # disable_ssl_validation: false
+    #
+    # Array of custom tags
+    # By default metrics and service check will be tagged by pool and host
+    # tags:
+    #   - instance:foo

--- a/php-fpm/fpm-nginx.compose
+++ b/php-fpm/fpm-nginx.compose
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  php_fpm:
+    image: "php:${version}"
+    volumes:
+        - ./provision/app:/app
+        - ./provision/php-fpm.conf:/usr/local/etc/php-fpm.d/php-fpm.conf
+  nginx:
+    image: nginx:latest
+    volumes:
+        - ./provision/app:/app
+        - ./provision/nginx.conf:/etc/nginx/conf.d/default.conf
+    labels:
+        com.datadoghq.sd.check.id: "php_fpm"
+
+
+networks:
+  default:
+    external:
+      name: workbench

--- a/php-fpm/manifest.yaml
+++ b/php-fpm/manifest.yaml
@@ -1,0 +1,12 @@
+name: php-fpm
+flavors:
+  nginx:
+    description: php-fpm behind a nginx server
+    compose_file: fpm-nginx.compose
+    options: &common_options
+      version:
+        description: Image version to run
+        values:
+          - "5.6-fpm"
+          - "7.0-fpm"
+        default: "7.0-fpm"

--- a/php-fpm/provision/app/index.php
+++ b/php-fpm/provision/app/index.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>

--- a/php-fpm/provision/nginx.conf
+++ b/php-fpm/provision/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /app;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php_fpm:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ ^/status$ {
+        access_log off;
+        fastcgi_pass php_fpm:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+}

--- a/php-fpm/provision/php-fpm.conf
+++ b/php-fpm/provision/php-fpm.conf
@@ -1,0 +1,1 @@
+pm.status_path = /status


### PR DESCRIPTION
We use nginx to serve the status page from php-fpm.

This is based on croissant-integration-resources