### PR TITLE
Add a new elastic flavor to use local folder as the data folder

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -7,7 +7,27 @@ Elasticsearch won't start if the following parameter hasn't that minimal value:
 sysctl -w vm.max_map_count=262144
 ```
 
-## Commands
+## fs.io_stats metrics
+
+Elasticsearch won't collect `fs.io_stats.total` metrics when running in docker
+with overlay. To test those metrics witht the agent you need to mount a folder
+from the host to the elasticsearch `data` folder.
+
+The `standalone_fs_stats` flavor do this for you (you need to create the
+`/tmp/elastic/` directory first).
+
+## Running
+* Launching elasticsearch standalone instance
+```bash
+COMPOSE_FILE=standalone.compose version=5.6 docker-compose up
+```
+
+* Launching a elasticsearch cluster
+```bash
+COMPOSE_FILE=standard.compose version=5.6 docker-compose up
+```
+
+## Useful Commands
 * Check elasticsearch health
   * Hint: default password is `changeme`
 ```bash

--- a/elasticsearch/manifest.yaml
+++ b/elasticsearch/manifest.yaml
@@ -13,6 +13,10 @@ flavors:
           - "5.3.3"
           - "5.4.2"
         default: "5.4.2"
+  standalone_fs_stats:
+    description: One elasticsearch instance with /tmp/elastic/ mount as the data volume (see README.md)
+    compose_file: standalone_data.compose
+    options: *common_options
   standard:
     description: Two elasticsearch nodes (see README.md)
     compose_file: standard.compose

--- a/elasticsearch/standalone_data.compose
+++ b/elasticsearch/standalone_data.compose
@@ -1,0 +1,25 @@
+version: '2'
+services:
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${version}"
+    labels:
+        com.datadoghq.sd.check.id: "elasticsearch"
+    ports:
+      - 9200
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - network.host=_eth0_,_local_
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+    volumes:
+      - /tmp/elastic:/usr/share/elasticsearch/data/
+
+networks:
+  default:
+    external:
+      name: workbench


### PR DESCRIPTION
New flavor allow us to test `fs.total.disk*` metrics with elastic 5+.