### PR TITLE
Enable dev_mode for agent5:release

### DIFF
--- a/datadog/agent5/manifest.yaml
+++ b/datadog/agent5/manifest.yaml
@@ -23,6 +23,7 @@ flavors:
     settings: &common_settings
       dd_api_key: required
       conf_d_path: required
+    dev_mode: true
   dev:
     description: dev-dd-agent image
     compose_file: dev.compose

--- a/datadog/agent5/release.compose
+++ b/datadog/agent5/release.compose
@@ -7,6 +7,7 @@ services:
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
       - ${conf_d_path}:/conf.d:ro
+      - ${integrations_core}:/checks.d:ro
     environment:
       API_KEY: ${dd_api_key}
       SD_BACKEND: docker


### PR DESCRIPTION
This allow us to test new versions of an integration with a released agent